### PR TITLE
fix: build emitter before playground bundle upload

### DIFF
--- a/eng/emitters/pipelines/templates/stages/emitter-stages.yml
+++ b/eng/emitters/pipelines/templates/stages/emitter-stages.yml
@@ -341,6 +341,12 @@ stages:
               - ${{ if parameters.UploadPlaygroundBundle }}:
                   - script: npm install -g pnpm
                     displayName: Install pnpm for playground bundle upload
+                  - script: npm ci
+                    displayName: Install emitter dependencies for playground bundle
+                    workingDirectory: $(Build.SourcesDirectory)/${{ parameters.PackagePath }}
+                  - script: npm run build:emitter
+                    displayName: Build emitter for playground bundle
+                    workingDirectory: $(Build.SourcesDirectory)/${{ parameters.PackagePath }}
                   - script: pnpm install --filter "@typespec/bundle-uploader..."
                     displayName: Install bundle-uploader dependencies
                     workingDirectory: $(Build.SourcesDirectory)


### PR DESCRIPTION
The emitter packages (http-client-csharp, http-client-python) are outside the pnpm workspace, so pnpm build doesn't cover them. Add npm ci + npm run build:emitter steps before bundling.