### PR TITLE
feat(compiler): allow inline decorators on declaration expressions

### DIFF
--- a/.chronus/changes/decl-expr-augment-inline-2026-4-18-0-0-2.md
+++ b/.chronus/changes/decl-expr-augment-inline-2026-4-18-0-0-2.md
@@ -1,0 +1,15 @@
+---
+changeKind: feature
+packages:
+  - "@typespec/compiler"
+---
+
+Allow augment decorators (`@@`) to target `model`, `enum`, `union`, and `scalar` declarations used in expression position (reached via a navigation reference such as `::type`).
+
+```tsp
+model Foo {
+  status: enum { active, inactive };
+}
+
+@@doc(Foo.status::type, "the current status");
+```

--- a/.chronus/changes/decl-expr-inline-decorators-2026-4-18-0-0-2.md
+++ b/.chronus/changes/decl-expr-inline-decorators-2026-4-18-0-0-2.md
@@ -1,0 +1,14 @@
+---
+changeKind: feature
+packages:
+  - "@typespec/compiler"
+---
+
+Allow decorators to be applied inline to `model`, `enum`, `union`, and `scalar` declarations used in expression position.
+
+```tsp
+model Foo {
+  status: @doc("the current status") enum { active, inactive };
+  inner: @doc("nested model") model Inner { x: string };
+}
+```

--- a/packages/compiler/src/core/checker.ts
+++ b/packages/compiler/src/core/checker.ts
@@ -7205,7 +7205,8 @@ export function createChecker(program: Program, resolver: NameResolver): Checker
     } else if (
       links.finalSymbol?.flags &&
       ~links.finalSymbol.flags & SymbolFlags.Declaration &&
-      ~links.finalSymbol.flags & SymbolFlags.Member
+      ~links.finalSymbol.flags & SymbolFlags.Member &&
+      !isDeclarationExpressionSym(links.finalSymbol)
     ) {
       program.reportDiagnostic(
         createDiagnostic({
@@ -7234,6 +7235,25 @@ export function createChecker(program: Program, resolver: NameResolver): Checker
 
     // If this was used to get a type this is invalid, only used for validation.
     return errorType;
+  }
+
+  /**
+   * A declaration expression (e.g. the `enum { a, b }` in `model Foo { x: enum { a, b } }`)
+   * is bound as a non-declaration symbol but is still a real, referenceable type
+   * (e.g. via `Foo.x::type`) and therefore a valid augment target. Statement-position
+   * declarations carry {@link SymbolFlags.Declaration} and never reach this check.
+   */
+  function isDeclarationExpressionSym(sym: Sym): boolean {
+    const symNode = getSymNode(sym);
+    switch (symNode?.kind) {
+      case SyntaxKind.ModelStatement:
+      case SyntaxKind.EnumStatement:
+      case SyntaxKind.UnionStatement:
+      case SyntaxKind.ScalarStatement:
+        return isDeclarationInExpressionPosition(symNode);
+      default:
+        return false;
+    }
   }
 
   /**

--- a/packages/compiler/src/core/parser.ts
+++ b/packages/compiler/src/core/parser.ts
@@ -1745,10 +1745,26 @@ function createParser(code: string | SourceFile, options: ParseOptions = {}): Pa
           return parseTupleExpression();
         case Token.OpenParen:
           return parseParenthesizedExpression();
-        case Token.At:
+        case Token.At: {
+          const pos = tokenPos();
           const decorators = parseDecoratorList();
-          reportInvalidDecorators(decorators, "expression");
-          continue;
+          // Decorators are only valid in expression position when they decorate a
+          // declaration expression (the keyword forms below). `pos` starts at the `@`
+          // so the resulting node span includes the decorators.
+          switch (token()) {
+            case Token.ModelKeyword:
+              return parseModelStatement(pos, decorators, [], true);
+            case Token.EnumKeyword:
+              return parseEnumStatement(pos, decorators, [], true);
+            case Token.UnionKeyword:
+              return parseUnionStatement(pos, decorators, [], true);
+            case Token.ScalarKeyword:
+              return parseScalarStatement(pos, decorators, [], true);
+            default:
+              reportInvalidDecorators(decorators, "expression");
+              continue;
+          }
+        }
         case Token.Hash:
           const directives = parseDirectiveList();
           reportInvalidDirective(directives, "expression");

--- a/packages/compiler/src/formatter/print/printer.ts
+++ b/packages/compiler/src/formatter/print/printer.ts
@@ -686,7 +686,9 @@ export function printEnumStatement(
   options: TypeSpecPrettierOptions,
   print: PrettierChildPrint,
 ) {
-  const { decorators } = printDecorators(path, options, print, { tryInline: false });
+  const { decorators } = printDecorators(path, options, print, {
+    tryInline: isInExpressionPosition(path),
+  });
   const id = path.node.id ? [" ", path.call(print, "id")] : "";
   return [
     decorators,
@@ -740,7 +742,9 @@ export function printUnionStatement(
   print: PrettierChildPrint,
 ) {
   const id = path.node.id ? [" ", path.call(print, "id")] : "";
-  const { decorators } = printDecorators(path, options, print, { tryInline: false });
+  const { decorators } = printDecorators(path, options, print, {
+    tryInline: isInExpressionPosition(path),
+  });
   const generic = printTemplateParameters(path, options, print, "templateParameters");
   return [
     decorators,
@@ -1083,7 +1087,7 @@ export function printModelStatement(
   const shouldPrintBody = nodeHasComments || !(node.properties.length === 0 && node.is);
   const body = shouldPrintBody ? [" ", printModelPropertiesBlock(path, options, print)] : ";";
   return [
-    printDecorators(path, options, print, { tryInline: false }).decorators,
+    printDecorators(path, options, print, { tryInline: isInExpressionPosition(path) }).decorators,
     printModifiers(path, options, print),
     "model",
     id,
@@ -1291,7 +1295,7 @@ function printScalarStatement(
       ? ""
       : ";";
   return [
-    printDecorators(path, options, print, { tryInline: false }).decorators,
+    printDecorators(path, options, print, { tryInline: inExpressionPosition }).decorators,
     printModifiers(path, options, print),
     "scalar",
     id,

--- a/packages/compiler/test/checker/declaration-expressions.test.ts
+++ b/packages/compiler/test/checker/declaration-expressions.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { Enum, Model, Scalar, Union } from "../../src/core/types.js";
-import { getTypeName } from "../../src/index.js";
+import { getDoc, getTypeName } from "../../src/index.js";
 import { expectDiagnosticEmpty, expectDiagnostics, t } from "../../src/testing/index.js";
 import { Tester } from "../tester.js";
 
@@ -373,8 +373,61 @@ describe("type name", () => {
 });
 
 describe("decorators", () => {
-  it("cannot decorate the declaration expression itself", async () => {
-    const diagnostics = await Tester.diagnose(`model Foo { x: @doc("hi") enum { a, b } }`);
+  it("applies a decorator to an anonymous enum expression", async () => {
+    const { program, Foo } = await Tester.compile(t.code`
+      model ${t.model("Foo")} {
+        status: @doc("the status") enum { active, inactive };
+      }
+    `);
+    const type = Foo.properties.get("status")!.type as Enum;
+    expect(type.kind).toBe("Enum");
+    expect(type.expression).toBe(true);
+    expect(getDoc(program, type)).toBe("the status");
+  });
+
+  it("applies a decorator to a named model declaration expression", async () => {
+    const { program, Foo } = await Tester.compile(t.code`
+      model ${t.model("Foo")} {
+        inner: @doc("the inner") model Inner { x: string };
+      }
+    `);
+    const type = Foo.properties.get("inner")!.type as Model;
+    expect(type.kind).toBe("Model");
+    expect(type.name).toBe("Inner");
+    expect(type.expression).toBe(true);
+    expect(getDoc(program, type)).toBe("the inner");
+  });
+
+  it("applies a decorator to a keyword union expression", async () => {
+    const { program, Foo } = await Tester.compile(t.code`
+      model ${t.model("Foo")} {
+        value: @doc("the value") union { string, int32 };
+      }
+    `);
+    const type = Foo.properties.get("value")!.type as Union;
+    expect(type.kind).toBe("Union");
+    expect(type.expression).toBe(true);
+    expect(getDoc(program, type)).toBe("the value");
+  });
+
+  it("applies a decorator to a scalar expression", async () => {
+    const { program, Foo } = await Tester.compile(t.code`
+      model ${t.model("Foo")} {
+        unit: @doc("the unit") scalar extends string;
+      }
+    `);
+    const type = Foo.properties.get("unit")!.type as Scalar;
+    expect(type.kind).toBe("Scalar");
+    expect(type.expression).toBe(true);
+    expect(getDoc(program, type)).toBe("the unit");
+  });
+
+  it("still rejects a decorator before a non-declaration expression", async () => {
+    const diagnostics = await Tester.diagnose(`
+      model Foo {
+        prop: @doc("nope") string;
+      }
+    `);
     expectDiagnostics(diagnostics, {
       code: "invalid-decorator-location",
       message: "Cannot decorate expression.",

--- a/packages/compiler/test/checker/declaration-expressions.test.ts
+++ b/packages/compiler/test/checker/declaration-expressions.test.ts
@@ -446,6 +446,78 @@ describe("decorators", () => {
   });
 });
 
+describe("augment decorators", () => {
+  it("can augment a named model declaration expression via ::type", async () => {
+    const { program, Foo } = await Tester.compile(t.code`
+      model ${t.model("Foo")} {
+        inner: model Inner { x: string };
+      }
+      @@doc(Foo.inner::type, "augmented");
+    `);
+    const type = Foo.properties.get("inner")!.type as Model;
+    expect(type.kind).toBe("Model");
+    expect(getDoc(program, type)).toBe("augmented");
+  });
+
+  it("can augment an anonymous enum declaration expression via ::type", async () => {
+    const { program, Foo } = await Tester.compile(t.code`
+      model ${t.model("Foo")} {
+        status: enum { active, inactive };
+      }
+      @@doc(Foo.status::type, "augmented");
+    `);
+    const type = Foo.properties.get("status")!.type as Enum;
+    expect(type.kind).toBe("Enum");
+    expect(getDoc(program, type)).toBe("augmented");
+  });
+
+  it("can augment a union declaration expression via ::type", async () => {
+    const { program, Foo } = await Tester.compile(t.code`
+      model ${t.model("Foo")} {
+        value: union { string, int32 };
+      }
+      @@doc(Foo.value::type, "augmented");
+    `);
+    const type = Foo.properties.get("value")!.type as Union;
+    expect(type.kind).toBe("Union");
+    expect(getDoc(program, type)).toBe("augmented");
+  });
+
+  it("can augment a scalar declaration expression via ::type", async () => {
+    const { program, Foo } = await Tester.compile(t.code`
+      model ${t.model("Foo")} {
+        unit: scalar Celsius extends int32;
+      }
+      @@doc(Foo.unit::type, "augmented");
+    `);
+    const type = Foo.properties.get("unit")!.type as Scalar;
+    expect(type.kind).toBe("Scalar");
+    expect(getDoc(program, type)).toBe("augmented");
+  });
+
+  it("still rejects augmenting an anonymous model expression", async () => {
+    const diagnostics = await Tester.diagnose(`
+      alias M = { x: string };
+      @@doc(M, "nope");
+    `);
+    expectDiagnostics(diagnostics, {
+      code: "augment-decorator-target",
+      message: "Cannot augment model expressions.",
+    });
+  });
+
+  it("still rejects augmenting a union expression", async () => {
+    const diagnostics = await Tester.diagnose(`
+      alias U = string | int32;
+      @@doc(U, "nope");
+    `);
+    expectDiagnostics(diagnostics, {
+      code: "augment-decorator-target",
+      message: "Cannot augment union expressions.",
+    });
+  });
+});
+
 describe("template parameters are not allowed in expression position", () => {
   it("reports a diagnostic for a templated model expression", async () => {
     const diagnostics = await Tester.diagnose(`alias M = model Foo<T> { x: T };`);

--- a/packages/compiler/test/formatter/formatter.test.ts
+++ b/packages/compiler/test/formatter/formatter.test.ts
@@ -1891,6 +1891,62 @@ alias N = model {
 `,
       });
     });
+
+    it("keeps a decorator inline on an enum expression", async () => {
+      await assertFormat({
+        code: `alias E = @doc("hi")enum {  a, b  };`,
+        expected: `
+alias E = @doc("hi") enum {
+  a,
+  b,
+};
+`,
+      });
+    });
+
+    it("keeps a decorator inline on a model expression property", async () => {
+      await assertFormat({
+        code: `model Foo { status:   @doc("the status")   enum {  active, inactive  }; }`,
+        expected: `
+model Foo {
+  status: @doc("the status") enum {
+    active,
+    inactive,
+  };
+}
+`,
+      });
+    });
+
+    it("keeps a decorator inline on a named model expression", async () => {
+      await assertFormat({
+        code: `alias M = @doc("d")model Inner {  x:  string  };`,
+        expected: `
+alias M = @doc("d") model Inner {
+  x: string;
+};
+`,
+      });
+    });
+
+    it("keeps a decorator inline on a union expression", async () => {
+      await assertFormat({
+        code: `alias U = @doc("d")union {  string, int32  };`,
+        expected: `
+alias U = @doc("d") union {
+  string,
+  int32,
+};
+`,
+      });
+    });
+
+    it("keeps a decorator inline on a scalar expression", async () => {
+      await assertFormat({
+        code: `alias S = @doc("d")scalar Celsius extends int32;`,
+        expected: `alias S = @doc("d") scalar Celsius extends int32;`,
+      });
+    });
   });
 
   describe("enum", () => {

--- a/packages/spec/src/spec.emu.html
+++ b/packages/spec/src/spec.emu.html
@@ -577,17 +577,17 @@ ModelExpression :
     `{` ModelBody? `}`
 
 ModelDeclarationExpression :
-    `model` Identifier? TemplateParameters? ExtendsModelHeritage? `{` ModelBody? `}`
+    DecoratorList? `model` Identifier? TemplateParameters? ExtendsModelHeritage? `{` ModelBody? `}`
 
 ScalarDeclarationExpression :
-    `scalar` Identifier? TemplateParameters? ScalarExtends?
-    `scalar` Identifier? TemplateParameters? ScalarExtends? `{` ScalarBody? `}`
+    DecoratorList? `scalar` Identifier? TemplateParameters? ScalarExtends?
+    DecoratorList? `scalar` Identifier? TemplateParameters? ScalarExtends? `{` ScalarBody? `}`
 
 EnumDeclarationExpression :
-    `enum` Identifier? `{` EnumBody? `}`
+    DecoratorList? `enum` Identifier? `{` EnumBody? `}`
 
 UnionDeclarationExpression :
-    `union` Identifier? `{` UnionBody? `}`
+    DecoratorList? `union` Identifier? `{` UnionBody? `}`
 
 TupleExpression :
     `[` ExpressionList? `]`


### PR DESCRIPTION
Stacked on top of the declarations-as-expressions work (#11019, branch `decl-expr`).

Enables applying decorators inline to `model`, `enum`, `union`, and `scalar` declarations used in **expression position**.

```tsp
model Foo {
  status: @doc("the current status") enum { active, inactive };
  inner: @doc("nested model") model Inner { x: string };
}
```

## Changes
- **Parser** (`parser.ts`): the `@` case in `parsePrimaryExpression` now parses a decorator list and, when followed by a `model`/`enum`/`union`/`scalar` keyword, dispatches to the corresponding `parse*Statement` (with `pos` captured at `@` so the node span includes the decorators). Decorators before any other expression still report `invalid-decorator-location` ("Cannot decorate expression.").
- **Grammar spec** (`spec.emu.html`): added the optional `DecoratorList?` prefix to the four `*DeclarationExpression` productions.
- **Formatter** (`printer.ts`): the four `print*Statement` printers now pass `tryInline: isInExpressionPosition(path)`, keeping decorators on the same line in expression position while statement-position decorators still break to their own line. Output is idempotent.

## Tests
- 5 checker tests: `@doc` applies to anonymous enum, named model, keyword union, and scalar declaration expressions (verified via `getDoc`), plus a negative case (decorator before a `string` reference still rejected).
- 6 formatter tests covering inline decorators on each kind.
- Full compiler suite: 4034 passed / 6 skipped.

## Discussion
- No checker changes were required — `parse*Statement` already plumbs `decorators` onto the AST node and the checker already applies `node.decorators`. The only blocker was the parser discarding decorators in expression position.